### PR TITLE
Add laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=7.1.3",
         "kalnoy/nestedset": "^5.0",
         "laravel/framework": ">=5.7",
-        "laravelcollective/html": ">=5.7"
+        "spatie/laravel-html": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0"

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,13 @@
         }
     ],
     "require": {
-        "php": ">=7.1.3",
+        "php": "^8.3",
         "kalnoy/nestedset": "^7.0",
-        "laravel/framework": ">=5.7",
+        "laravel/framework": ">=13.0",
         "spatie/laravel-html": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^12.5.12"
     },
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "kalnoy/nestedset": "^5.0",
+        "kalnoy/nestedset": "^7.0",
         "laravel/framework": ">=5.7",
         "spatie/laravel-html": "^3.0"
     },

--- a/src/Adapters/LaravelCollectiveFormAdapter.php
+++ b/src/Adapters/LaravelCollectiveFormAdapter.php
@@ -88,7 +88,7 @@ class LaravelCollectiveFormAdapter
     /**
      * Create a select box field.
      */
-    public static function select(string $name, array $list = [], $selected = null, array $options = []): HtmlString
+    public static function select(string $name, iterable $list = [], $selected = null, array $options = []): HtmlString
     {
         $select = html()->select($name, $list, $selected);
         return new HtmlString(self::applyAttributes($select, $options));

--- a/src/Adapters/LaravelCollectiveFormAdapter.php
+++ b/src/Adapters/LaravelCollectiveFormAdapter.php
@@ -1,0 +1,392 @@
+<?php
+
+namespace PhpCollective\MenuMaker\Adapters;
+
+use Illuminate\Support\HtmlString;
+
+class LaravelCollectiveFormAdapter
+{
+    /**
+     * Open up a new HTML form.
+     */
+    public static function open(array $options = []): HtmlString
+    {
+        $method = $options['method'] ?? 'POST';
+        $url = self::resolveAction($options);
+
+        $form = html()->form($method, $url);
+        $form = self::applyAttributes($form, $options);
+
+        return new HtmlString($form->open());
+    }
+
+    /**
+     * Open a new model-backed HTML form.
+     */
+    public static function model($model, array $options = []): HtmlString
+    {
+        $method = $options['method'] ?? 'POST';
+        $url = self::resolveAction($options);
+
+        // Spatie tracks model state globally when modelForm is initialized
+        $form = html()->modelForm($model, $method, $url);
+        $form = self::applyAttributes($form, $options);
+
+        return new HtmlString($form->open());
+    }
+
+    /**
+     * Close the current form.
+     */
+    public static function close(): HtmlString
+    {
+        html()->endModel();
+
+        return new HtmlString((string) html()->element('form')->close());
+    }
+
+    /**
+     * Create a text input field.
+     */
+    public static function text(string $name, ?string $value = null, array $options = []): HtmlString
+    {
+        $input = html()->text($name, $value);
+        return new HtmlString(self::applyAttributes($input, $options));
+    }
+
+    /**
+     * Create a hidden input field.
+     */
+    public static function hidden(string $name, ?string $value = null, array $options = []): HtmlString
+    {
+        $input = html()->hidden($name, $value);
+        return new HtmlString(self::applyAttributes($input, $options));
+    }
+
+    /**
+     * Create a textarea input field.
+     */
+    public static function textarea(string $name, ?string $value = null, array $options = []): HtmlString
+    {
+        $textarea = html()->textarea($name, $value);
+        return new HtmlString(self::applyAttributes($textarea, $options));
+    }
+
+    /**
+     * Create a checkbox input field.
+     *
+     * A hidden input with value 0 is prepended so that unchecked state is
+     * still submitted (standard HTML omits unchecked checkboxes entirely).
+     */
+    public static function checkbox(string $name, $value = 1, ?bool $checked = null, array $options = []): HtmlString
+    {
+        $hidden   = html()->hidden($name, 0)->forgetAttribute('id')->toHtml();
+        $checkbox = html()->checkbox($name, $checked, $value);
+        return new HtmlString($hidden . self::applyAttributes($checkbox, $options));
+    }
+
+    /**
+     * Create a select box field.
+     */
+    public static function select(string $name, array $list = [], $selected = null, array $options = []): HtmlString
+    {
+        $select = html()->select($name, $list, $selected);
+        return new HtmlString(self::applyAttributes($select, $options));
+    }
+
+    /**
+     * Create a submit button.
+     */
+    public static function submit(?string $value = null, array $options = []): HtmlString
+    {
+        $submit = html()->submit($value);
+        return new HtmlString(self::applyAttributes($submit, $options));
+    }
+
+    /**
+     * Output the CSRF hidden input token field.
+     */
+    public static function token(): HtmlString
+    {
+        return new HtmlString(html()->token());
+    }
+
+    /**
+     * Create a label element.
+     */
+    public static function label(string $name, ?string $value = null, array $options = [], bool $escape = true): HtmlString
+    {
+        $label = $escape
+            ? html()->label(null, $name)->text($value)
+            : html()->label(null, $name)->html($value);
+        return new HtmlString(self::applyAttributes($label, $options));
+    }
+
+    /**
+     * Create a password input field.
+     */
+    public static function password(string $name, array $options = []): HtmlString
+    {
+        $input = html()->password($name);
+        return new HtmlString(self::applyAttributes($input, $options));
+    }
+
+    /**
+     * Create an email input field.
+     */
+    public static function email(string $name, ?string $value = null, array $options = []): HtmlString
+    {
+        $input = html()->email($name, $value);
+        return new HtmlString(self::applyAttributes($input, $options));
+    }
+
+    /**
+     * Create a tel input field.
+     */
+    public static function tel(string $name, ?string $value = null, array $options = []): HtmlString
+    {
+        $input = html()->input('tel', $name, $value);
+        return new HtmlString(self::applyAttributes($input, $options));
+    }
+
+    /**
+     * Create a number input field.
+     */
+    public static function number(string $name, $value = null, array $options = []): HtmlString
+    {
+        $min  = $options['min']  ?? null;
+        $max  = $options['max']  ?? null;
+        $step = $options['step'] ?? null;
+        unset($options['min'], $options['max'], $options['step']);
+        $input = html()->number($name, $value, $min, $max, $step);
+        return new HtmlString(self::applyAttributes($input, $options));
+    }
+
+    /**
+     * Create a date input field.
+     */
+    public static function date(string $name, ?string $value = null, array $options = []): HtmlString
+    {
+        $input = html()->date($name, $value);
+        return new HtmlString(self::applyAttributes($input, $options));
+    }
+
+    /**
+     * Create a datetime-local input field (legacy 'datetime' alias).
+     */
+    public static function datetime(string $name, ?string $value = null, array $options = []): HtmlString
+    {
+        $input = html()->datetime($name, $value);
+        return new HtmlString(self::applyAttributes($input, $options));
+    }
+
+    /**
+     * Create a datetime-local input field.
+     */
+    public static function datetimeLocal(string $name, ?string $value = null, array $options = []): HtmlString
+    {
+        $input = html()->datetime($name, $value);
+        return new HtmlString(self::applyAttributes($input, $options));
+    }
+
+    /**
+     * Create a time input field.
+     */
+    public static function time(string $name, ?string $value = null, array $options = []): HtmlString
+    {
+        $input = html()->time($name, $value);
+        return new HtmlString(self::applyAttributes($input, $options));
+    }
+
+    /**
+     * Create a url input field.
+     */
+    public static function url(string $name, ?string $value = null, array $options = []): HtmlString
+    {
+        $input = html()->input('url', $name, $value);
+        return new HtmlString(self::applyAttributes($input, $options));
+    }
+
+    /**
+     * Create a search input field.
+     */
+    public static function search(string $name, ?string $value = null, array $options = []): HtmlString
+    {
+        $input = html()->search($name, $value);
+        return new HtmlString(self::applyAttributes($input, $options));
+    }
+
+    /**
+     * Create a month input field.
+     */
+    public static function month(string $name, ?string $value = null, array $options = []): HtmlString
+    {
+        $input = html()->input('month', $name, $value);
+        return new HtmlString(self::applyAttributes($input, $options));
+    }
+
+    /**
+     * Create a week input field.
+     */
+    public static function week(string $name, ?string $value = null, array $options = []): HtmlString
+    {
+        $input = html()->input('week', $name, $value);
+        return new HtmlString(self::applyAttributes($input, $options));
+    }
+
+    /**
+     * Create a color input field.
+     */
+    public static function color(string $name, ?string $value = null, array $options = []): HtmlString
+    {
+        $input = html()->input('color', $name, $value);
+        return new HtmlString(self::applyAttributes($input, $options));
+    }
+
+    /**
+     * Create a range input field.
+     */
+    public static function range(string $name, $value = null, array $options = []): HtmlString
+    {
+        $min  = $options['min']  ?? null;
+        $max  = $options['max']  ?? null;
+        $step = $options['step'] ?? null;
+        unset($options['min'], $options['max'], $options['step']);
+        $input = html()->range($name, $value, $min, $max, $step);
+        return new HtmlString(self::applyAttributes($input, $options));
+    }
+
+    /**
+     * Create a generic input field.
+     */
+    public static function input(string $type, string $name, ?string $value = null, array $options = []): HtmlString
+    {
+        $input = html()->input($type, $name, $value);
+        return new HtmlString(self::applyAttributes($input, $options));
+    }
+
+    /**
+     * Create a file input field.
+     */
+    public static function file(string $name, array $options = []): HtmlString
+    {
+        $input = html()->file($name);
+        return new HtmlString(self::applyAttributes($input, $options));
+    }
+
+    /**
+     * Create a select box over a numeric range.
+     */
+    public static function selectRange(string $name, int $begin, int $end, $selected = null, array $options = []): HtmlString
+    {
+        $range = array_combine(range($begin, $end), range($begin, $end));
+        return self::select($name, $range, $selected, $options);
+    }
+
+    /**
+     * Create a select box populated with a range of years.
+     */
+    public static function selectYear(string $name, int $begin, int $end, $selected = null, array $options = []): HtmlString
+    {
+        return self::selectRange($name, $begin, $end, $selected, $options);
+    }
+
+    /**
+     * Create a select box populated with month names.
+     */
+    public static function selectMonth(string $name, $selected = null, array $options = [], string $format = 'F'): HtmlString
+    {
+        $months = [];
+        for ($i = 1; $i <= 12; $i++) {
+            $date = \DateTime::createFromFormat('n', (string)$i);
+            $months[$i] = $date->format($format);
+        }
+        return self::select($name, $months, $selected, $options);
+    }
+
+    /**
+     * Create a radio input field.
+     */
+    public static function radio(string $name, $value = null, ?bool $checked = null, array $options = []): HtmlString
+    {
+        $radio = html()->radio($name, $checked, $value);
+        return new HtmlString(self::applyAttributes($radio, $options));
+    }
+
+    /**
+     * Create a button element.
+     */
+    public static function button(?string $value = null, array $options = []): HtmlString
+    {
+        $type   = $options['type'] ?? 'button';
+        unset($options['type']);
+        $button = html()->button($value, $type);
+        return new HtmlString(self::applyAttributes($button, $options));
+    }
+
+    /**
+     * Create a reset button.
+     */
+    public static function reset(?string $value = null, array $options = []): HtmlString
+    {
+        $reset = html()->reset($value);
+        return new HtmlString(self::applyAttributes($reset, $options));
+    }
+
+    /**
+     * Create an image input (submit button with image).
+     */
+    public static function image(string $src, ?string $name = null, array $options = []): HtmlString
+    {
+        $input = html()->input('image', $name)->attribute('src', $src);
+        return new HtmlString(self::applyAttributes($input, $options));
+    }
+
+    /**
+     * Helper to resolve routes or URLs from options array.
+     */
+    protected static function resolveAction(array &$options): string
+    {
+        if (isset($options['route'])) {
+            $routeData = $options['route'];
+            unset($options['route']);
+
+            return is_array($routeData)
+                ? route($routeData[0], array_slice($routeData, 1))
+                : route($routeData);
+        }
+
+        if (isset($options['url'])) {
+            $url = $options['url'];
+            unset($options['url']);
+            return $url;
+        }
+
+        return '';
+    }
+
+    /**
+     * Helper to loop through the old array options and chain them for Spatie.
+     */
+    protected static function applyAttributes($spatieElement, array $options)
+    {
+        // Handle file uploads flag mapping
+        if (isset($options['files']) && $options['files'] === true) {
+            $spatieElement = $spatieElement->acceptsFiles();
+            unset($options['files']);
+        }
+
+        // Clean up framework action verbs before mapping HTML attributes
+        unset($options['method']);
+
+        foreach ($options as $key => $value) {
+            if (method_exists($spatieElement, $key)) {
+                $spatieElement = $spatieElement->$key($value);
+            } else {
+                $spatieElement = $spatieElement->attribute($key, $value);
+            }
+        }
+
+        return $spatieElement;
+    }
+}

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -40,29 +40,6 @@ class InstallCommand extends Command
             '--force'   => true
         ]);
 
-        $this->registerMenuAuthorizationMiddleware();
-
         $this->info('Menu scaffolding installed successfully.');
-    }
-
-    /**
-     * Register the Menu authorization middleware in the application Kernel file.
-     *
-     * @return void
-     */
-    protected function registerMenuAuthorizationMiddleware()
-    {
-        $bootstrapFile = base_path('bootstrap/app.php');
-        $bootstrapContents = file_get_contents($bootstrapFile);
-
-        if (Str::contains($bootstrapContents, 'VerifyMenuAuthorization::class')) {
-            return;
-        }
-
-        file_put_contents($bootstrapFile, str_replace(
-            '->withMiddleware(function (Middleware $middleware) {',
-            '->withMiddleware(function (Middleware $middleware) {'.PHP_EOL."        \$middleware->alias(['menu' => \\PhpCollective\\MenuMaker\\Http\\Middleware\\VerifyMenuAuthorization::class]);",
-            $bootstrapContents
-        ));
     }
 }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -52,15 +52,17 @@ class InstallCommand extends Command
      */
     protected function registerMenuAuthorizationMiddleware()
     {
-        $kernelFile = file_get_contents(app_path('Http/Kernel.php'));
-        if (Str::contains($kernelFile, '\\PhpCollective\\MenuMaker\\Http\\Middleware\\VerifyMenuAuthorization::class')) {
+        $bootstrapFile = base_path('bootstrap/app.php');
+        $bootstrapContents = file_get_contents($bootstrapFile);
+
+        if (Str::contains($bootstrapContents, 'VerifyMenuAuthorization::class')) {
             return;
         }
 
-        file_put_contents(app_path('Http/Kernel.php'), str_replace(
-            "\\Illuminate\Auth\Middleware\Authorize::class,".PHP_EOL,
-            "\\Illuminate\Auth\Middleware\Authorize::class,".PHP_EOL."        'menu' => \\PhpCollective\MenuMaker\Http\Middleware\VerifyMenuAuthorization::class,".PHP_EOL,
-            $kernelFile
+        file_put_contents($bootstrapFile, str_replace(
+            '->withMiddleware(function (Middleware $middleware) {',
+            '->withMiddleware(function (Middleware $middleware) {'.PHP_EOL."        \$middleware->alias(['menu' => \\PhpCollective\\MenuMaker\\Http\\Middleware\\VerifyMenuAuthorization::class]);",
+            $bootstrapContents
         ));
     }
 }

--- a/src/MenuMaker.php
+++ b/src/MenuMaker.php
@@ -58,11 +58,34 @@ trait MenuMaker
 
     protected function getMenuItems()
     {
-        return Cache::rememberForever('menus.section.' . optional($this->section)->id . '.user.' . $this->id, function () {
-            return $this->admin()
+        $cached = Cache::rememberForever('menus.section.' . optional($this->section)->id . '.user.' . $this->id, function () {
+            $items = $this->admin()
                 ? $this->getAdminMenuItems()
                 : $this->getUserMenuItems();
+            return $this->menuTreeToArray($items);
         });
+
+        return $this->menuArrayToCollection($cached);
+    }
+
+    private function menuTreeToArray($collection): array
+    {
+        $result = [];
+        foreach ($collection as $key => $item) {
+            $item['children'] = $this->menuTreeToArray($item['children']);
+            $result[$key] = $item;
+        }
+        return $result;
+    }
+
+    private function menuArrayToCollection(array $items)
+    {
+        $collection = collect([]);
+        foreach ($items as $key => $item) {
+            $item['children'] = $this->menuArrayToCollection($item['children']);
+            $collection->put($key, $item);
+        }
+        return $collection;
     }
 
     private function getAdminMenuItems()

--- a/src/MenuServiceProvider.php
+++ b/src/MenuServiceProvider.php
@@ -43,6 +43,10 @@ class MenuServiceProvider extends ServiceProvider
         $this->loadTranslationsFrom(
             __DIR__ . '/../resources/lang', 'menu-maker'
         );
+
+        if (! class_exists('Form', false)) { // in case the same php process is reused and the alias is already registered
+            class_alias(\PhpCollective\MenuMaker\Adapters\LaravelCollectiveFormAdapter::class, 'Form');
+        }
     }
 
     /**

--- a/src/MenuServiceProvider.php
+++ b/src/MenuServiceProvider.php
@@ -47,8 +47,6 @@ class MenuServiceProvider extends ServiceProvider
         if (! class_exists('Form', false)) { // in case the same php process is reused and the alias is already registered
             class_alias(\PhpCollective\MenuMaker\Adapters\LaravelCollectiveFormAdapter::class, 'Form');
         }
-
-        Route::aliasMiddleware('menu', \PhpCollective\MenuMaker\Http\Middleware\VerifyMenuAuthorization::class);
     }
 
     /**
@@ -61,6 +59,8 @@ class MenuServiceProvider extends ServiceProvider
         Route::group($this->routeConfiguration(), function () {
             $this->loadRoutesFrom(__DIR__ . '/Http/routes.php');
         });
+
+        Route::aliasMiddleware('menu', \PhpCollective\MenuMaker\Http\Middleware\VerifyMenuAuthorization::class);
     }
 
     /**

--- a/src/MenuServiceProvider.php
+++ b/src/MenuServiceProvider.php
@@ -47,6 +47,8 @@ class MenuServiceProvider extends ServiceProvider
         if (! class_exists('Form', false)) { // in case the same php process is reused and the alias is already registered
             class_alias(\PhpCollective\MenuMaker\Adapters\LaravelCollectiveFormAdapter::class, 'Form');
         }
+
+        Route::aliasMiddleware('menu', \PhpCollective\MenuMaker\Http\Middleware\VerifyMenuAuthorization::class);
     }
 
     /**

--- a/src/Observers/MenuObserver.php
+++ b/src/Observers/MenuObserver.php
@@ -11,7 +11,7 @@ class MenuObserver
     /**
      * Handle the User "created" event.
      *
-     * @param  \App\Menu  $menu
+     * @param  Menu  $menu
      * @return void
      */
     public function created(Menu $menu)
@@ -22,7 +22,7 @@ class MenuObserver
     /**
      * Handle the Menu "updated" event.
      *
-     * @param  \App\Menu  $menu
+     * @param  Menu  $menu
      * @return void
      */
     public function updated(Menu $menu)

--- a/src/Observers/MenuObserver.php
+++ b/src/Observers/MenuObserver.php
@@ -2,11 +2,8 @@
 
 namespace PhpCollective\MenuMaker\Observers;
 
-
-use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Artisan;
 use PhpCollective\MenuMaker\Storage\Menu;
-use PhpCollective\MenuMaker\Storage\Role;
-use PhpCollective\MenuMaker\Jobs\RemoveUserMenuCache;
 
 class MenuObserver
 {
@@ -19,7 +16,7 @@ class MenuObserver
      */
     public function created(Menu $menu)
     {
-        $this->removeAdminCache();
+        $this->removeCache();
     }
 
     /**
@@ -30,8 +27,7 @@ class MenuObserver
      */
     public function updated(Menu $menu)
     {
-        $this->removeAdminCache();
-        $this->removeUserCache($menu);
+        $this->removeCache();
     }
 
     /**
@@ -42,43 +38,16 @@ class MenuObserver
      */
     public function deleting(Menu $menu)
     {
-        $this->removeAdminCache();
-        $this->removeUserCache($menu);
+        $this->removeCache();
     }
 
     /**
-     * Handle User Cache delete.
-     *
-     * @param  Menu  $menu
-     * @return void
-     */
-    private function removeUserCache(Menu $menu)
-    {
-        $menu->load('roles', 'roles.users');
-        $menu->roles->each(function ($role) {
-            $role->users->each(function ($user) {
-                RemoveUserMenuCache::dispatch($user);
-            });
-        });
-    }
-
-    /**
-     * Handle Admin User Cache delete.
+     * Handle Cache Clear.
      *
      * @return void
      */
-    private function removeAdminCache()
+    private function removeCache()
     {
-        Cache::forget('public-routes');
-
-        $admin = Role::with('users')->admin()->first();
-        if(! $admin)
-        {
-            return;
-        }
-
-        $admin->users->each(function ($user) {
-            RemoveUserMenuCache::dispatch($user);
-        });
+        Artisan::call('menu:clear');
     }
 }

--- a/src/Storage/Permission.php
+++ b/src/Storage/Permission.php
@@ -60,7 +60,7 @@ class Permission extends Model
 
     public static function routes()
     {
-        return Cache::remember('routes', now()->addHour(), function () {
+        return collect(Cache::remember('routes', now()->addHour(), function () {
             $filterRoutes = [];
             $routes = Route::getRoutes();
             foreach ($routes as $route) {
@@ -69,8 +69,8 @@ class Permission extends Model
                 }
                 $filterRoutes[] = explode_route($route);
             }
-            return collect($filterRoutes);
-        });
+            return $filterRoutes;
+        }));
     }
 
     public static function excludedActionList()
@@ -89,9 +89,9 @@ class Permission extends Model
 
     public static function publicRoutes()
     {
-        return Cache::rememberForever('public-routes', function () {
-            return collect(self::public()->get()->toArray());
-        });
+        return collect(Cache::rememberForever('public-routes', function () {
+            return self::public()->get()->toArray();
+        }));
     }
 
     public static function actions()


### PR DESCRIPTION
Its a major upgrade. While releasing, semantic version number's major identifier must be increased to ensure existing production applications using this package can continue using older versions. For example, if the current version is v1.0.15, new version number should be v2.0.0